### PR TITLE
Handling missing locales gracefully.

### DIFF
--- a/src/components/dt-base.js
+++ b/src/components/dt-base.js
@@ -41,7 +41,11 @@ export default class DtBase extends LitElement {
 
     // if locale is changing, update lit-localize
     if (props && props.has('locale') && this.locale) {
-      setLocale(this.locale);
+      try {
+        setLocale(this.locale);
+      } catch (e) {
+        console.error(e);
+      }
     }
   }
 }


### PR DESCRIPTION
A missing locale was causing crashes. This handles the error more gracefully by sending it to the console.