### PR TITLE
Making tile headings conditional

### DIFF
--- a/src/components/layout/dt-tile/dt-tile.js
+++ b/src/components/layout/dt-tile/dt-tile.js
@@ -1,4 +1,4 @@
-import { html, css } from 'lit';
+import { html, css, nothing } from 'lit';
 import DtBase from '../../dt-base.js';
 
 export class DtTile extends DtBase {
@@ -85,6 +85,10 @@ export class DtTile extends DtBase {
     };
   }
 
+  get hasHeading() {
+    return this.title || this.expands;
+  }
+
   _toggle() {
     // const body = this.renderRoot.querySelector('.section-body');
     // if (!this.collapsed && body && body.clientHeight) {
@@ -93,9 +97,12 @@ export class DtTile extends DtBase {
     this.collapsed = !this.collapsed;
   }
 
-  render() {
+  renderHeading() {
+    if (!this.hasHeading) {
+      return nothing
+    }
+
     return html`
-      <section>
         <h3 class="section-header">
           ${this.title}
           ${this.expands
@@ -109,6 +116,13 @@ export class DtTile extends DtBase {
               `
             : null}
         </h3>
+    `
+  }
+
+  render() {
+    return html`
+      <section>
+        ${this.renderHeading()}
         <div class="section-body ${this.collapsed ? 'collapsed' : null}">
           <slot></slot>
         </div>


### PR DESCRIPTION
Empty tile headings currently lead to extra whitespace. 