### PR TITLE
Proxying focus events to the root element.

### DIFF
--- a/src/components/dt-base.js
+++ b/src/components/dt-base.js
@@ -75,8 +75,6 @@ export default class DtBase extends LitElement {
    * @returns
    */
   _proxyFocus() {
-    console.log('focusing', this._focusTarget);
-
     if (!this._focusTarget) {
       return;
     }

--- a/src/components/dt-base.js
+++ b/src/components/dt-base.js
@@ -9,15 +9,25 @@ export default class DtBase extends LitElement {
   static get properties() {
     return {
       locale: { type: String },
-      apiRoot: {type: String, reflect: false},
-      postType: {type: String, reflect: false},
-      postID: {type: String, reflect: false},
+      apiRoot: { type: String, reflect: false },
+      postType: { type: String, reflect: false },
+      postID: { type: String, reflect: false },
     };
+  }
+
+  /**
+   * return the element to proxy focus to
+   */
+  get _focusTarget() {
+    return this.shadowRoot.children[0] instanceof Element
+      ? this.shadowRoot.children[0]
+      : null;
   }
 
   constructor() {
     super();
     updateWhenLocaleChanges(this);
+    this.addEventListener('focus', this._proxyFocus.bind(this));
   }
 
   connectedCallback() {
@@ -58,5 +68,19 @@ export default class DtBase extends LitElement {
         console.error(e);
       }
     }
+  }
+
+  /**
+   * Proxy focus to the focus target
+   * @returns
+   */
+  _proxyFocus() {
+    console.log('focusing', this._focusTarget);
+
+    if (!this._focusTarget) {
+      return;
+    }
+
+    this._focusTarget.focus();
   }
 }

--- a/src/components/form/dt-form-base.js
+++ b/src/components/form/dt-form-base.js
@@ -64,6 +64,20 @@ export default class DtFormBase extends DtBase {
     };
   }
 
+  /**
+   * return the field elemnt
+   */
+  get _field() {
+    return this.shadowRoot.querySelector('input, textarea, select');
+  }
+
+  /**
+   * return the element to proxy focus to
+   */
+  get _focusTarget() {
+    return this._field;
+  }
+
   constructor() {
     super();
     this.touched = false;


### PR DESCRIPTION
You are currently not able to tab to elements using keyboard input. That means no tabbing between fields and no tabbing to buttons to submit via keyboard.

I've added tab support to all components. The `get _focusTarget(): Element` getter can be overwritten to target a custom focus target. Form elements also now have a `get _field` getter than acts as a convenience accessor to return the field element within the component. 