### PR TITLE
Reporting number field errors.

### DIFF
--- a/src/components/form/dt-number/dt-number.js
+++ b/src/components/form/dt-number/dt-number.js
@@ -40,6 +40,9 @@ export class DtNumberField extends DtFormBase {
           background-color: var(--dt-form-disabled-background-color, #e6e6e6);
           cursor: not-allowed;
         }
+        input:invalid {
+          border-color: var(--dt-form-invalid-border-color, #dc3545);
+        }
       `,
     ];
   }
@@ -53,12 +56,20 @@ export class DtNumberField extends DtFormBase {
         type: String,
         reflect: true,
       },
+      oldValue: {
+        type: String,
+      },
       min: { type: Number },
       max: { type: Number },
       loading: { type: Boolean },
       saved: { type: Boolean },
       onchange: { type: String },
     };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.oldValue = this.value;
   }
 
   _checkValue(value) {
@@ -78,24 +89,44 @@ export class DtNumberField extends DtFormBase {
           newValue: e.target.value,
         },
         bubbles: true,
-        composed: true
+        composed: true,
       });
 
       this.value = e.target.value;
+      this._field.setCustomValidity('');
       this.dispatchEvent(event);
+      this.api = new ApiService(this.nonce, `${this.apiRoot}`);
 
-      this.api = new ApiService(this.nonce, this.apiRoot);
-
-
-      const response = await this.api.updatePost(this.postType, this.postID, {
-        [this.name]: e.target.value,
-      });
-
-      this.saved = true;
-
+      try {
+        const response = await this.api.updatePost(this.postType, this.postID, {
+          [this.name]: e.target.value,
+        });
+        if (response.data && response.data.status !== 200) {
+          this.handleError(response.message);
+        } else {
+          this.saved = true;
+          this.oldValue = this.value;
+        }
+      } catch (error) {
+        this.handleError(error);
+      }
     } else {
       e.currentTarget.value = '';
     }
+  }
+
+  handleError(er = 'An error occurred.') {
+    let error = er;
+    if (error instanceof Error) {
+      console.error(error);
+      error = error.message;
+    } else {
+      console.error(error);
+    }
+    this.error = error;
+    this._field.setCustomValidity(error);
+    this.invalid = true;
+    this.value = this.oldValue;
   }
 
   render() {


### PR DESCRIPTION
https://www.loom.com/share/9bf8acfae1ce4fad88289eed4184bd03

Number field errors were not reported, so the user didn't know if the update failed. This pull request sets the field to an :invalid state, console logs the error, and resets the field value to the pre-submission value. 