### PR TITLE
Rounded button improvements

### DIFF
--- a/src/components/form/dt-button/dt-button.js
+++ b/src/components/form/dt-button/dt-button.js
@@ -33,10 +33,10 @@ export class DtButton extends DtBase {
         );
         color: var(--dt-button-context-text-color, var(--dt-button-text-color));
         text-rendering: optimizeLegibility;
-        gap: 10px;
-        justify-content: center;
-        align-content: center;
-        align-items: center;
+        gap: var(--dt-button-gap, 10px);
+        justify-content: var(--dt-button-justify-content, center);
+        align-content: var(--dt-button-align-content, center);
+        align-items: var(--dt-button-align-items, center);
         text-decoration: var(
           --dt-button-text-decoration,
           var(--dt-button-context-text-decoration, none)
@@ -130,9 +130,7 @@ export class DtButton extends DtBase {
         --dt-button-border-radius: 50%;
         --dt-button-padding-x: 0px;
         --dt-button-padding-y: 0px;
-        --dt-button-width: var(--dt-button-width, 1.2em);
-        --dt-button-aspect-ratio: var(--dt-button-aspect-ratio, 1/1);
-        --dt-button-line-height: var(--dt-button-height, inherit);
+        --dt-button-aspect-ratio: var(--dt-button-rounded-aspect-ratio, 1/1);
       }
 
       button.toggle {


### PR DESCRIPTION
Safari was not rendering rounded buttons properly, which led me to discover that Safari and Chrome handle custom property definition inheritance differently. 

When defining a custom properly, safari does not use specificity when determining which variable declaration is applied first, which makes using class-based property overrides impossible unless you use different variable names.

I also added a few new custom properties.