### PR TITLE
Removing select options did not update form value.

### DIFF
--- a/src/components/form/dt-multi-select/dt-multi-select.js
+++ b/src/components/form/dt-multi-select/dt-multi-select.js
@@ -332,6 +332,7 @@ export class DtMultiSelect extends DtFormBase {
 
       // dispatch event for use with addEventListener from javascript
       this.dispatchEvent(event);
+      this._setFormValue(this.value);
 
       // If option was de-selected while list was open, re-focus input
       if (this.open) {


### PR DESCRIPTION
The form value was not updated when options were removed, so manual form submissions were not updated with the removed value.