### PR TITLE
Fixing safari modal height bug

### DIFF
--- a/src/components/layout/dt-modal/dt-modal.js
+++ b/src/components/layout/dt-modal/dt-modal.js
@@ -16,13 +16,14 @@ export class DtModal extends DtBase {
       }
 
       .dt-modal {
-        display: grid;
+        display: block;
         background: var(--dt-modal-background-color, #fff);
         color: var(--dt-modal-color, #000);
         max-inline-size: min(90vw, 100%);
         max-block-size: min(80vh, 100%);
         max-block-size: min(80dvb, 100%);
         margin: auto;
+        height: fit-content;
         padding: var(--dt-modal-padding, 1em);
         position: fixed;
         inset: 0;
@@ -68,6 +69,7 @@ export class DtModal extends DtBase {
 
       form {
         display: grid;
+        height: fit-content;
         grid-template-columns: 1fr;
         grid-template-rows: 100px auto 100px;
         grid-template-areas:


### PR DESCRIPTION
.dt-modal was stretching to the full height of the screen on Safari instead of collapsing to child height as it does on other browsers. The modal's grid structure is set on the form element, not the .dt-modal element, so I changed .dt-modal to be block instead of grid and collapsed it using `height: fit-content`. 

![Screenshot 2023-05-22 at 12 00 25 PM](https://github.com/DiscipleTools/disciple-tools-web-components/assets/5910297/acc44c1b-044c-4f5e-8f1b-ff3a7a492cd2)

![Screenshot 2023-05-22 at 12 00 08 PM](https://github.com/DiscipleTools/disciple-tools-web-components/assets/5910297/e816a614-d85f-4989-b096-1b9a2adf57b4)
