### PR TITLE
Changes for dt-tag and dt-connection option list to exclude selected options

### DIFF
--- a/src/components/form/dt-connection/dt-connection.js
+++ b/src/components/form/dt-connection/dt-connection.js
@@ -146,7 +146,7 @@ export class DtConnection extends DtTags {
 
       // need to fetch data via API request
       const self = this;
-      const event = new CustomEvent('focus', {
+      const event = new CustomEvent('dt:get-data', {
         bubbles: true,
         detail: {
           field: this.name,

--- a/src/components/form/dt-connection/dt-connection.js
+++ b/src/components/form/dt-connection/dt-connection.js
@@ -138,7 +138,7 @@ export class DtConnection extends DtTags {
               .toLocaleLowerCase()
               .includes(this.query.toLocaleLowerCase()))
       );
-    } else if (this.open) {
+    } else if (this.open || this.canUpdate) {
       // Only run this filtering if the list is open.
       // This prevents it from running on initial load before a `load` event is attached.
       this.loading = true;
@@ -146,7 +146,7 @@ export class DtConnection extends DtTags {
 
       // need to fetch data via API request
       const self = this;
-      const event = new CustomEvent('load', {
+      const event = new CustomEvent('focus', {
         bubbles: true,
         detail: {
           field: this.name,
@@ -163,6 +163,7 @@ export class DtConnection extends DtTags {
           onError: error => {
             console.warn(error);
             self.loading = false;
+            this.canUpdate = false;
           },
         },
       });
@@ -215,6 +216,7 @@ export class DtConnection extends DtTags {
           data-label="${opt.label}"
           @click="${this._clickOption}"
           @touchstart="${this._touchStart}"
+          @blur="${this._inputFocusOut}"
           @touchmove="${this._touchMove}"
           @touchend="${this._touchEnd}"
           tabindex="-1"

--- a/src/components/form/dt-connection/dt-connection.test.js
+++ b/src/components/form/dt-connection/dt-connection.test.js
@@ -282,7 +282,7 @@ describe('dt-connection', () => {
 
     setTimeout(() => sendKeys({ type: 'o' }));
 
-    const { detail } = await oneEvent(el, 'load');
+    const { detail } = await oneEvent(el, 'dt:get-data');
 
     expect(detail.field).to.equal('custom-name');
     expect(detail.query).to.equal('o');

--- a/src/components/form/dt-multi-select/dt-multi-select.js
+++ b/src/components/form/dt-multi-select/dt-multi-select.js
@@ -216,6 +216,7 @@ export class DtMultiSelect extends HasOptionsList(DtFormBase) {
     event.detail.newValue = this.value;
     this.open = false; // close options list
     this.activeIndex = -1; // reset keyboard-selected option
+    this.canUpdate = true;
 
     // dispatch event for use with addEventListener from javascript
     this.dispatchEvent(event);

--- a/src/components/form/dt-tags/dt-tags.js
+++ b/src/components/form/dt-tags/dt-tags.js
@@ -64,7 +64,7 @@ export class DtTags extends DtMultiSelect {
 
       // need to fetch data via API request
       const self = this;
-      const event = new CustomEvent('focus', {
+      const event = new CustomEvent('dt:get-data', {
         bubbles: true,
         detail: {
           field: this.name,

--- a/src/components/form/dt-tags/dt-tags.js
+++ b/src/components/form/dt-tags/dt-tags.js
@@ -56,7 +56,7 @@ export class DtTags extends DtMultiSelect {
               .toLocaleLowerCase()
               .includes(this.query.toLocaleLowerCase()))
       );
-    } else if (this.open) {
+    } else if (this.open || this.canUpdate) {
       // Only run this filtering if the list is open.
       // This prevents it from running on initial load before a `load` event is attached.
       this.loading = true;
@@ -64,7 +64,7 @@ export class DtTags extends DtMultiSelect {
 
       // need to fetch data via API request
       const self = this;
-      const event = new CustomEvent('load', {
+      const event = new CustomEvent('focus', {
         bubbles: true,
         detail: {
           field: this.name,
@@ -90,6 +90,7 @@ export class DtTags extends DtMultiSelect {
           onError: error => {
             console.warn(error);
             self.loading = false;
+            this.canUpdate = false;
           },
         },
       });
@@ -107,6 +108,7 @@ export class DtTags extends DtMultiSelect {
           data-label="${opt.label}"
           @click="${this._clickOption}"
           @touchstart="${this._touchStart}"
+          @blur="${this._inputFocusOut}"
           @touchmove="${this._touchMove}"
           @touchend="${this._touchEnd}"
           tabindex="-1"

--- a/src/components/form/dt-tags/dt-tags.test.js
+++ b/src/components/form/dt-tags/dt-tags.test.js
@@ -326,7 +326,7 @@ describe('dt-tags', () => {
 
     setTimeout(() => sendKeys({ type: 'o' }));
 
-    const { detail } = await oneEvent(el, 'load');
+    const { detail } = await oneEvent(el, 'dt:get-data');
 
     expect(detail.field).to.equal('custom-name');
     expect(detail.query).to.equal('o');
@@ -353,7 +353,7 @@ describe('dt-tags', () => {
 
     setTimeout(() => sendKeys({ type: 'o' }));
 
-    const { detail } = await oneEvent(el, 'load');
+    const { detail } = await oneEvent(el, 'dt:get-data');
 
     expect(detail.field).to.equal('custom-name');
     expect(detail.query).to.equal('o');

--- a/src/components/form/mixins/hasOptionsList.js
+++ b/src/components/form/mixins/hasOptionsList.js
@@ -26,6 +26,10 @@ export const HasOptionsList = (superClass) => class extends superClass {
         type: Boolean,
         state: true,
       },
+      canUpdate:{
+        type:Boolean,
+        state: true
+      },
       activeIndex: {
         type: Number,
         state: true,
@@ -99,6 +103,7 @@ export const HasOptionsList = (superClass) => class extends superClass {
       !['BUTTON', 'LI'].includes(e.relatedTarget.nodeName)
     ) {
       this.open = false;
+      this.canUpdate = true;
     }
   }
 

--- a/src/services/componentService.js
+++ b/src/services/componentService.js
@@ -57,7 +57,7 @@ export default class ComponentService {
     );
     if (elements) {
       elements.forEach(el =>
-        el.addEventListener('dt:get-data', this.handleLoadEvent.bind(this))
+        el.addEventListener('dt:get-data', this.handleGetDataEvent.bind(this))
       )
     }
   }
@@ -83,7 +83,7 @@ export default class ComponentService {
    * @param {Event} event
    * @returns {Promise<void>}
    */
-  async handleLoadEvent(event) {
+  async handleGetDataEvent(event) {
     const details = event.detail;
     if (details) {
       const { field, query, onSuccess, onError } = details;

--- a/src/services/componentService.js
+++ b/src/services/componentService.js
@@ -94,18 +94,18 @@ export default class ComponentService {
           case 'dt-connection': {
             const postType = details.postType || this.postType;
             const connectionResponse = await this.api.listPostsCompact(postType, query);
-            //for filtering the user itself from the response.
+            // for filtering the user itself from the response.
             const filteredConnectionResponse = {
               ...connectionResponse,
-              posts: connectionResponse.posts.filter(post => post.ID !== parseInt(this.postId))
+              posts: connectionResponse.posts.filter(post => post.ID !== parseInt(this.postId, 10))
           };
-          
+
           if (filteredConnectionResponse?.posts) {
             values = filteredConnectionResponse?.posts.map(value => ({
-              id: value['ID'],
-              label: value['name'],
-              link: value['permalink'],
-              status: value['status'],
+              id: value.ID,
+              label: value.name,
+              link: value.permalink,
+              status: value.status,
             }));
           }
           break;
@@ -221,7 +221,6 @@ export default class ComponentService {
 
         case 'dt-comm-channel':
           if (typeof value === 'string') {
-            console.log('dt-comm-channel', value);
             returnValue = [
               {
                 id: value,

--- a/src/services/componentService.js
+++ b/src/services/componentService.js
@@ -57,7 +57,7 @@ export default class ComponentService {
     );
     if (elements) {
       elements.forEach(el =>
-        el.addEventListener('focus', this.handleLoadEvent.bind(this))
+        el.addEventListener('dt:get-data', this.handleLoadEvent.bind(this))
       )
     }
   }

--- a/src/services/componentService.js
+++ b/src/services/componentService.js
@@ -57,7 +57,7 @@ export default class ComponentService {
     );
     if (elements) {
       elements.forEach(el =>
-        el.addEventListener('load', this.handleLoadEvent.bind(this))
+        el.addEventListener('focus', this.handleLoadEvent.bind(this))
       )
     }
   }
@@ -94,15 +94,21 @@ export default class ComponentService {
           case 'dt-connection': {
             const postType = details.postType || this.postType;
             const connectionResponse = await this.api.listPostsCompact(postType, query);
-            if (connectionResponse?.posts) {
-              values = connectionResponse?.posts.map(value => ({
-                id: value['ID'],
-                label: value['name'],
-                link: value['permalink'],
-                status: value['status'],
-              }));
-            }
-            break;
+            //for filtering the user itself from the response.
+            const filteredConnectionResponse = {
+              ...connectionResponse,
+              posts: connectionResponse.posts.filter(post => post.ID !== parseInt(this.postId))
+          };
+          
+          if (filteredConnectionResponse?.posts) {
+            values = filteredConnectionResponse?.posts.map(value => ({
+              id: value['ID'],
+              label: value['name'],
+              link: value['permalink'],
+              status: value['status'],
+            }));
+          }
+          break;
           }
           case 'dt-tags':
           default:


### PR DESCRIPTION
Hi @micahmills 

1. We have made code changes to exclude the selected Items from the options list in Dt-Connection, Dt-Tags & Dt-Multiselect components. I.e. those components that fetched its option list(dropdown) from API.  The following files have been changed. 
          - src\components\form\dt-multi-select\dt-multi-select.js
          - src\components\form\dt-tags\dt-tags.js
          - src\components\form\dt-connection\dt-connection.js
          - src\components\form\mixins\hasOptionsList.js
          - src\services\componentService.js
 2. On the Edit detail page in the DT Theme, the Options List for Dt-connection-related fields also displayed the particular user (current user). That must be excluded from the list. We have made these changes in the File 
src\services\componentService.js  at Line No.: 98

Could you review the changes and give us your feedback? Thanks!

@Ashima-Arora @gp-birender