### PR TITLE
Removed Multiselect Item Backspace Case

### DIFF
--- a/src/components/form/mixins/hasOptionsList.js
+++ b/src/components/form/mixins/hasOptionsList.js
@@ -125,13 +125,6 @@ export const HasOptionsList = (superClass) => class extends superClass {
     const keycode = e.keyCode || e.which;
 
     switch (keycode) {
-      case 8: // backspace
-        if (e.target.value === '') {
-          this.value = this.value.slice(0, -1);
-        } else {
-          this.open = true;
-        }
-        break;
       case 38: // arrow up
         this.open = true;
         this._listHighlightPrevious();


### PR DESCRIPTION
Removed the backspacing on multi-select items to prevent accidentally removing an item, resolves issue #131