### PR TITLE
Multi-Select Components Search Clearing fix

### DIFF
--- a/src/components/form/dt-connection/dt-connection.js
+++ b/src/components/form/dt-connection/dt-connection.js
@@ -81,6 +81,7 @@ export class DtConnection extends DtTags {
       const input = this.shadowRoot.querySelector('input');
       if (input) {
         input.value = '';
+        this.query = '';
       }
     }
   }

--- a/src/components/form/dt-multi-select/dt-multi-select.js
+++ b/src/components/form/dt-multi-select/dt-multi-select.js
@@ -232,6 +232,7 @@ export class DtMultiSelect extends HasOptionsList(DtFormBase) {
     // dispatch event for use with addEventListener from javascript
     this.dispatchEvent(event);
     this._setFormValue(this.value);
+    this.query = '';
   }
 
   _remove(e) {

--- a/src/components/form/dt-tags/dt-tags.js
+++ b/src/components/form/dt-tags/dt-tags.js
@@ -66,6 +66,7 @@ export class DtTags extends DtMultiSelect {
       },
     });
 
+    this.query = '';
     this.dispatchEvent(event);
   }
 


### PR DESCRIPTION
Fixed issue #140 where searches for connection, tags, and multi-select fields wouldn't be removed after selecting a value, leaving you unable to clear the search.

Clearing the query that is referenced in the dtBase function seemed like the simple solution - let me know if this isn't what you're looking for.