### PR TITLE
multi-select search query fix

### DIFF
--- a/src/components/form/dt-connection/dt-connection.js
+++ b/src/components/form/dt-connection/dt-connection.js
@@ -66,7 +66,6 @@ export class DtConnection extends DtTags {
       if (option) {
         this._select(option);
       }
-      this._clearSearch();
     }
   }
 
@@ -96,7 +95,6 @@ export class DtConnection extends DtTags {
       } else {
         this._select(this.filteredOptions[this.activeIndex]);
       }
-      this._clearSearch();
     }
   }
 

--- a/src/components/form/dt-location/dt-location.js
+++ b/src/components/form/dt-location/dt-location.js
@@ -50,7 +50,6 @@ export class DtLocation extends DtTags {
         return result;
       }, null);
       this._select(option);
-      this._clearSearch();
     }
   }
 

--- a/src/components/form/dt-multi-select/dt-multi-select.js
+++ b/src/components/form/dt-multi-select/dt-multi-select.js
@@ -235,6 +235,7 @@ export class DtMultiSelect extends HasOptionsList(DtFormBase) {
     if (this.query) {
       this.query = '';
     }
+    this._clearSearch();
   }
 
   _remove(e) {

--- a/src/components/form/dt-users-connection/dt-users-connection.js
+++ b/src/components/form/dt-users-connection/dt-users-connection.js
@@ -92,6 +92,7 @@ export class DtUsersConnection extends DtTags {
     // dispatch event for use with addEventListener from javascript
     this.dispatchEvent(event);
     this._setFormValue(this.value);
+    this._clearSearch();
   }
 
   _clickOption(e) {
@@ -106,7 +107,6 @@ export class DtUsersConnection extends DtTags {
       if (option) {
         this._select(option);
       }
-      this._clearSearch();
       this.query = '';
     }
   }
@@ -138,7 +138,6 @@ export class DtUsersConnection extends DtTags {
       } else {
         this._select(this.filteredOptions[this.activeIndex]);
       }
-      this._clearSearch();
       this.query = '';
     }
   }

--- a/src/components/form/mixins/hasOptionsList.js
+++ b/src/components/form/mixins/hasOptionsList.js
@@ -86,6 +86,7 @@ export const HasOptionsList = (superClass) => class extends superClass {
 
   _select() { // eslint-disable-line class-methods-use-this
     console.error("Must implement `_select(value)` function");
+    this._clearSearch();
   }
 
   /* Search Input Field Events */
@@ -211,14 +212,12 @@ export const HasOptionsList = (superClass) => class extends superClass {
       } else {
         this._select(this.filteredOptions[this.activeIndex].id);
       }
-      this._clearSearch();
     }
   }
 
   _clickOption(e) {
     if (e.target && e.target.value) {
       this._select(e.target.value);
-      this._clearSearch();
     }
   }
 
@@ -226,7 +225,6 @@ export const HasOptionsList = (superClass) => class extends superClass {
     if (e.target) {
       this._select(e.target.dataset?.label);
       // clear search field if clicked with mouse, since field will lose focus
-      this._clearSearch();
     }
   }
 


### PR DESCRIPTION
@cairocoder01 In response to @corsacca 's comment on disciple-tools-theme #2758:
Location field would keep the search text after selecting an option. Additionally, all multi-select fields kept the current filtered list even after the search text was removed, so I removed the query itself from multi-selects _select() function.