### PR TITLE
Avoid loading Google SDK multiple times when using the geocoder in a magic link

### DIFF
--- a/src/components/form/dt-location-map/dt-location-map-item.js
+++ b/src/components/form/dt-location-map/dt-location-map-item.js
@@ -273,8 +273,11 @@ export default class DtLocationMapItem extends DtBase {
     if (this.mapboxToken) {
       this.mapboxService = new MapboxService(this.mapboxToken);
     }
+  }
 
-    if (this.googleToken) {
+  firstUpdated() {
+    // Only load Google Maps API for new/empty location items
+    if (this.googleToken && !this.metadata?.lat) {
       this.googleGeocodeService = new GoogleGeocodeService(this.googleToken, window, document);
     }
   }

--- a/src/components/form/dt-location-map/dt-map-modal.js
+++ b/src/components/form/dt-location-map/dt-map-modal.js
@@ -54,7 +54,6 @@ export class DtMapModal extends DtBase {
       script.src = 'https://api.mapbox.com/mapbox-gl-js/v2.11.0/mapbox-gl.js';
       script.onload = this.initMap.bind(this);
       document.body.appendChild(script);
-      console.log('injected script')
     } else {
       this.initMap();
     }
@@ -148,7 +147,7 @@ export class DtMapModal extends DtBase {
   }
 
   render() {
-    return html`      
+    return html`
       <dt-modal
         .title=${this.metadata?.label}
         ?isopen=${this.isOpen}
@@ -158,10 +157,10 @@ export class DtMapModal extends DtBase {
         <div slot="content">
           <div class="map" id="map"></div>
         </div>
-       
+
         ${this.canEdit ? html`<div slot="close-button">${msg('Save')}</div>` : null}
       </dt-modal>
-      
+
       <link href='https://api.mapbox.com/mapbox-gl-js/v2.11.0/mapbox-gl.css' rel='stylesheet' />
     `;
   }

--- a/src/services/googleGeocodeService.js
+++ b/src/services/googleGeocodeService.js
@@ -4,13 +4,9 @@ export default class GoogleGeocodeService {
     this.window = window;
 
     if (!window.google?.maps?.places?.AutocompleteService) {
-      // Check if a Google Maps script tag already exists (may still be loading)
-      const existingScript = document.querySelector('script[src*="maps.googleapis.com/maps/api/js"]');
-      if (!existingScript) {
-        const script = document.createElement('script');
-        script.src = `https://maps.googleapis.com/maps/api/js?libraries=places&key=${token}`;
-        document.body.appendChild(script);
-      }
+      const script = document.createElement('script');
+      script.src = `https://maps.googleapis.com/maps/api/js?libraries=places&key=${token}`;
+      document.body.appendChild(script);
     }
   }
   /**


### PR DESCRIPTION
Using theGoogle Geolocator on a magic link with a location field that had already several location values saved. 
 The Google Geolocation SDK was being loaded multiple times. One per location already saved. 


Solution:

  Moved GoogleGeocodeService initialization from
  connectedCallback() to firstUpdated() with a check for
  existing coordinates:

  firstUpdated() {
    // Only load Google Maps API for new/empty location items
    if (this.googleToken && !this.metadata?.lat) {
      this.googleGeocodeService = new
  GoogleGeocodeService(this.googleToken, window, document);
    }
  }

  Items with existing coordinates don't need geocoding (they
  already have lat/lng), so they skip API loading entirely.