### PR TITLE
synced component height

### DIFF
--- a/src/components/form/dt-date/dt-date.js
+++ b/src/components/form/dt-date/dt-date.js
@@ -28,7 +28,7 @@ export class DtDate extends DtFormBase {
           font-family: inherit;
           font-size: 1rem;
           font-weight: 300;
-          height: auto;
+          height: 2.5rem;
           line-height: 1.5;
           margin: 0;
           padding: var(--dt-form-padding, 0.5333333333rem);
@@ -115,6 +115,7 @@ export class DtDate extends DtFormBase {
         }
 
         .input-addon.btn-clear {
+          height: 2.5rem;
           color: var(--alert-color, #cc4b37);
           &:disabled {
             color: var(--dt-date-placeholder-color, #999);

--- a/src/components/form/dt-location-map/dt-location-map-item.js
+++ b/src/components/form/dt-location-map/dt-location-map-item.js
@@ -131,6 +131,7 @@ export default class DtLocationMapItem extends DtBase {
           font-weight: 300;
           line-height: 1.5;
           margin: 0;
+          height: 2.5rem;
           padding: var(--dt-form-padding, 0.5333333333rem);
           transition: var(
             --dt-form-transition,
@@ -184,6 +185,7 @@ export default class DtLocationMapItem extends DtBase {
           border-width: var(--dt-form-border-width, 1px);
         }
         .field-container .input-addon {
+          height: 2.5rem;
           flex-shrink: 1;
           display: flex;
           justify-content: center;

--- a/src/components/form/dt-multi-select/dt-multi-select.js
+++ b/src/components/form/dt-multi-select/dt-multi-select.js
@@ -46,9 +46,9 @@ export class DtMultiSelect extends HasOptionsList(DtFormBase) {
           min-height: 2.5rem;
           line-height: 1.5;
           margin: 0;
-          padding-top: calc(0.5rem - 0.375rem);
-          padding-bottom: 0.5rem;
-          padding-inline: 0.5rem 1.6rem;
+          padding-top: 0.25rem;
+          padding-bottom: 0.25rem;
+          padding-inline: 0.25rem 1.6rem;
           box-sizing: border-box;
           width: 100%;
           text-transform: none;
@@ -74,7 +74,8 @@ export class DtMultiSelect extends HasOptionsList(DtFormBase) {
           position: relative;
           border-radius: 2px;
           margin-inline-end: 4px;
-          margin-block-start: 0.375rem;
+          margin-block-start: 0.1rem;
+          margin-block-end: 0.1rem;
           box-sizing: border-box;
           min-width: 0;
         }

--- a/src/components/form/dt-multi-text/dt-multi-text.js
+++ b/src/components/form/dt-multi-text/dt-multi-text.js
@@ -35,7 +35,7 @@ export class DtMultiText extends DtText {
           font-family: inherit;
           font-size: 1rem;
           font-weight: 300;
-          height: auto;
+          height: 2.5rem;
           line-height: 1.5;
           margin: 0;
           padding: var(--dt-form-padding, 0.5333333333rem);
@@ -86,6 +86,7 @@ export class DtMultiText extends DtText {
           flex-grow: 1;
         }
         .field-container .input-addon {
+          height: 2.5rem;
           flex-shrink: 1;
           display: flex;
           justify-content: center;


### PR DESCRIPTION
For #160 I synced the height of all components. @cairocoder01 let me know your thoughts!

I used Dt-text as a basis, with height set to 2.5rem. I set all components' heights to 2.5rem as well to match.

For multi-select fields, I left height as auto so it's able to display properly when selected values move to the next line.